### PR TITLE
Fixed Worker won't run because of too few parameters

### DIFF
--- a/app/src/main/java/com/vikiwahyudi/deteksigempadantsunami/ui/settings/NotificationTerkiniWorker.kt
+++ b/app/src/main/java/com/vikiwahyudi/deteksigempadantsunami/ui/settings/NotificationTerkiniWorker.kt
@@ -1,5 +1,6 @@
 package com.vikiwahyudi.deteksigempadantsunami.ui.settings
 
+import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -14,6 +15,7 @@ import androidx.work.WorkerParameters
 import com.vikiwahyudi.deteksigempadantsunami.R
 import com.vikiwahyudi.deteksigempadantsunami.data.DataGempaRepository
 import com.vikiwahyudi.deteksigempadantsunami.data.remote.response.terkini.TerkiniResponse
+import com.vikiwahyudi.deteksigempadantsunami.di.Injection
 import com.vikiwahyudi.deteksigempadantsunami.network.StatusResponse
 import com.vikiwahyudi.deteksigempadantsunami.ui.HomeActivity
 import com.vikiwahyudi.deteksigempadantsunami.utils.CHANNEL_NAME
@@ -23,10 +25,11 @@ import com.vikiwahyudi.deteksigempadantsunami.utils.NOTIFICATION_CHANNEL_ID
 
 class NotificationTerkiniWorker(
     ctx: Context,
-    params: WorkerParameters,
-    private val networkRepository: DataGempaRepository,
-    private val notificationPreference: NotificationPreference
+    params: WorkerParameters
 ) : Worker(ctx, params) {
+
+    private lateinit var networkRepository: DataGempaRepository
+    private lateinit var notificationPreference: NotificationPreference
 
     private fun getPendingIntent(gempaItem: TerkiniResponse): PendingIntent? {
         val intent = Intent(applicationContext, HomeActivity::class.java).apply {
@@ -40,6 +43,9 @@ class NotificationTerkiniWorker(
 
     override fun doWork(): Result {
         IdlingResources.beginIdle()
+        networkRepository = Injection.provideRepository(applicationContext)
+        notificationPreference = NotificationPreference(applicationContext as Application)
+
         val api = networkRepository.getAutoGempaSync()
         val local = notificationPreference.initComponents().getLastInfo()
 


### PR DESCRIPTION
Worker itu secara default (tanpa di injeksi pakai Hilt/Koin) pembentukan class nya kek gini vik:
```
class TaskWorker(
    context: Context,
    workerParams: WorkerParams
) : Worker(context, workerParams) {
    ...
}
```

Worker dengan constructor kek di atas bakal bisa jalan, soalnya secara bawaannya WorkManager itu di WorkerFactory cuma punya dan bisanya 2 parameter data aja, dan sementara punyamu butuh 4 parameter data. Itulah kenapa Worker nya nggak mau jalan, karena pas WorkerFactory nya inisialisasi Worker yang kamu buat itu masih kekurangan argumen data. Alhasil, kamu butuh WorkerFactory klo mau handle biar parameter yg dibutuhkan bisa lebih dari 2

Karena kamu pake injeksi manual, jadinya aku pindahin 2 parameter di constructor nya ke fungsi turunan
```
doWork()
```
dan aku panggil semua class yang dibutuhkan jadi variabel. Cuma ini emg resikonya, keterkaitan antar class jadi kuat (_tightly coupling_).

btw, WorkManager bisa kamu pelajari dan coba latihannya di kelas Fundamental Dicoding: [Belajar Fundamental Aplikasi Android - WorkManager](https://www.dicoding.com/academies/14/tutorials/5631)

Note: WorkManager kalo jenisnya PeriodicWork paling kecil **15 menit sekali**, gak bisa di bawah itu